### PR TITLE
Cleanup index partitioning code

### DIFF
--- a/src/reddit/headers/CommentFeatureChunks.h
+++ b/src/reddit/headers/CommentFeatureChunks.h
@@ -72,7 +72,7 @@ public:
     while (iter != rhs.end()) {
       int myKey = (*iter).key;
       if (feature_chunk->count(myKey) != 0) {
-        std::cout << "FAILED!!" << std::endl;
+        std::cout << "[COMMENT FEATURE CHUNKS] Failed Aggregation! Expected count of " << myKey << " to be 0, but was " << feature_chunk->count(myKey) << std::endl;
         exit(1);
       }
       (*feature_chunk)[myKey] = (*iter).value;

--- a/src/reddit/headers/CommentPartition.h
+++ b/src/reddit/headers/CommentPartition.h
@@ -16,16 +16,17 @@ namespace reddit {
 class CommentPartition : public PartitionComp<int, Comment> {
 public:
   ENABLE_DEEP_COPY
+  int range;
 
   CommentPartition() {}
 
-  CommentPartition(std::string dbname, std::string setname) {
+  CommentPartition(int range, std::string dbname, std::string setname) : range(range) {
     this->setOutput(dbname, setname);
   }
 
   Lambda<int> getProjection(Handle<Comment> checkMe) override {
     return makeLambda(
-        checkMe, [this](Handle<Comment> &checkMe) { return checkMe->index; });
+        checkMe, [this](Handle<Comment> &checkMe) { return (int) checkMe->index / range; });
   }
 };
 } // namespace reddit


### PR DESCRIPTION
Fix index partitioning

Changes:
1. RedditFeatureExtractor binary needs a new argument while invoking, which specifies the setName of the reddit comments. The signature is now - `./bin/RedditFeatureExtractor <comments_set_name> <block_x> <block_y> <total_comments> <optional: path_to_model_params>`
2. New binary added - loadRedditCommentsIndexPartition to load Reddit comments and partition them on their index. Signature is `./bin/loadRedditCommentsIndexPartition <host> <port> <path_to_comments> <run_computation> <delete_existing_data> <partition_range>`. We can runComputation first so that the self learning db knows about the partitioning technique. Then we can run without the computation again.