### PR TITLE
Fix and cleanup SimpleFF

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -50,6 +50,7 @@ elif  common_env['PLATFORM'] == 'posix':
     common_env.Append(LINKFLAGS = '-pthread -ldl -lgsl -lgslcblas -lm -lsnappy -lstdc++ -lcrypto -lssl')
     common_env.Replace(CXX = "clang++")
 
+common_env.Append(CCFLAGS='-DDEBUG_SIMPLE_FF')
 #common_env.Append(CCFLAGS='-DDEBUG_VTABLE_FIXING')
 #common_env.Append(CCFLAGS='-DDEBUG_SHUFFLING')
 common_env.Append(CCFLAGS='-DINITIALIZE_ALLOCATOR_BLOCK')

--- a/src/FF/headers/FFInputLayerJoin.h
+++ b/src/FF/headers/FFInputLayerJoin.h
@@ -45,7 +45,7 @@ public:
             pdb::Handle<FFMatrixBlock> resultFFMatrixBlock =
                 pdb::makeObject<FFMatrixBlock>(
                     in1->getBlockRowIndex(), in2->getBlockColIndex(), I, J,
-                    in1->getTotalRowNums(), in2->getTotalColNums());
+                    in1->getTotalRowNums(), in2->getTotalColNums(), false);
 
             // get the ptrs
             double *outData = resultFFMatrixBlock->getValue().rawData->c_ptr();

--- a/src/FF/headers/FFMatrixUtil.h
+++ b/src/FF/headers/FFMatrixUtil.h
@@ -7,6 +7,7 @@
 
 namespace pdb {
 class PDBClient;
+class CatalogClient;
 class String;
 } // namespace pdb
 
@@ -14,7 +15,7 @@ namespace ff {
 int load_matrix_data(pdb::PDBClient &pdbClient, std::string path,
                      pdb::String dbName, pdb::String setName, int blockX,
                      int blockY, bool dont_pad_x, bool dont_pad_y,
-                     std::string &errMsg);
+                     std::string &errMsg, bool partitionByCol = true);
 
 void loadMatrix(pdb::PDBClient &pdbClient, pdb::String dbName,
                 pdb::String setName, int totalX, int totalY, int blockX,
@@ -28,4 +29,6 @@ void print_stats(pdb::PDBClient &pdbClient, std::string dbName,
                  std::string setName);
 
 void print(pdb::PDBClient &pdbClient, std::string dbName, std::string setName);
+
+bool is_empty_set(pdb::PDBClient &pdbClient, pdb::CatalogClient &catalogClient, std::string dbName, std::string setName);
 } // namespace ff

--- a/src/FF/headers/FFOutputLayer.h
+++ b/src/FF/headers/FFOutputLayer.h
@@ -31,7 +31,7 @@ public:
             uint32_t I = in1->getRowNums();
             uint32_t J = in1->getColNums();
 
-            if (in1->getRowNums() != in2->getRowNums()) {
+            if (in1->getRowNums() != in2->getRowNums() || in2->getColNums() != 1) {
               cout << "[FFOutputLayer] Cannot divide! Dimensions mismatch!"
                    << endl;
               exit(-1);
@@ -41,7 +41,7 @@ public:
             pdb::Handle<FFMatrixBlock> resultFFMatrixBlock =
                 pdb::makeObject<FFMatrixBlock>(
                     in1->getBlockRowIndex(), in1->getBlockColIndex(), I, J,
-                    in1->getTotalRowNums(), in1->getTotalColNums());
+                    in1->getTotalRowNums(), in1->getTotalColNums(), false);
 
             // get the ptrs
             double *outData = resultFFMatrixBlock->getValue().rawData->c_ptr();

--- a/src/FF/headers/FFReluBiasSum.h
+++ b/src/FF/headers/FFReluBiasSum.h
@@ -58,7 +58,7 @@ public:
             pdb::Handle<FFMatrixBlock> resultFFMatrixBlock =
                 pdb::makeObject<FFMatrixBlock>(
                     in1->getBlockRowIndex(), in1->getBlockColIndex(), I, J,
-                    in1->getTotalRowNums(), in1->getTotalColNums());
+                    in1->getTotalRowNums(), in1->getTotalColNums(), false);
 
             double *outData = resultFFMatrixBlock->getValue().rawData->c_ptr();
             double *in1Data = in1->getValue().rawData->c_ptr();

--- a/src/FF/headers/FFTransposeBiasSum.h
+++ b/src/FF/headers/FFTransposeBiasSum.h
@@ -52,7 +52,7 @@ public:
             pdb::Handle<FFMatrixBlock> resultFFMatrixBlock =
                 pdb::makeObject<FFMatrixBlock>(
                     in1->getBlockColIndex(), in1->getBlockRowIndex(), J, I,
-                    in1->getTotalColNums(), in1->getTotalRowNums());
+                    in1->getTotalColNums(), in1->getTotalRowNums(), false);
 
             double *outData = resultFFMatrixBlock->getValue().rawData->c_ptr();
             double *in1Data = in1->getValue().rawData->c_ptr();

--- a/src/FF/headers/FFTransposeMult.h
+++ b/src/FF/headers/FFTransposeMult.h
@@ -49,7 +49,7 @@ public:
             pdb::Handle<FFMatrixBlock> resultFFMatrixBlock =
                 pdb::makeObject<FFMatrixBlock>(
                     in1->getBlockRowIndex(), in2->getBlockRowIndex(), I, J,
-                    in1->getTotalRowNums(), in2->getTotalRowNums());
+                    in1->getTotalRowNums(), in2->getTotalRowNums(), false);
 
             // get the ptrs
             double *outData = resultFFMatrixBlock->getValue().rawData->c_ptr();

--- a/src/FF/headers/InferenceResult.h
+++ b/src/FF/headers/InferenceResult.h
@@ -45,6 +45,13 @@ public:
     std::cout << (*inference)[0] << ", " << (*inference)[1] << std::endl;
   }
 
+  void print() {
+    for (int i = 0; i < inference->size(); i++) {
+      std::cout << (*inference)[i] << ",";
+    }
+    std::cout << std::endl;
+  }
+
   InferenceResult &getValue() { return *this; }
 
   size_t hash() const override{

--- a/src/FF/headers/SimpleFF.h
+++ b/src/FF/headers/SimpleFF.h
@@ -15,8 +15,11 @@ namespace ff {
 void loadLibrary(pdb::PDBClient &pdbClient, std::string path);
 
 void createSet(pdb::PDBClient &pdbClient, std::string dbName,
-               std::string setName, std::string setName1, std::string jobName = "",
-               std::string computationName = "", std::string lambdaName = "");
+               std::string setName, std::string setName1);
+
+void createSet(pdb::PDBClient &pdbClient, std::string dbName,
+               std::string setName, std::string setName1, std::string jobName,
+               std::string computationName, std::string lambdaName);
 
 
 
@@ -33,4 +36,6 @@ void inference(pdb::PDBClient &pdbClient, std::string database, std::string w1,
                std::string w2, std::string wo, std::string inputs,
                std::string b1, std::string b2, std::string bo,
                pdb::Handle<pdb::Computation> &output, double dropout_rate, bool enablePartition=false);
+
+void cleanup(pdb::PDBClient &pdblient, std::string database);
 } // namespace ff

--- a/src/FF/source/FFMatrixUtil.cc
+++ b/src/FF/source/FFMatrixUtil.cc
@@ -10,7 +10,7 @@ using namespace std;
 namespace ff {
 int load_matrix_data(pdb::PDBClient &pdbClient, string path, pdb::String dbName,
                      pdb::String setName, int blockX, int blockY,
-                     bool dont_pad_x, bool dont_pad_y, string &errMsg) {
+                     bool dont_pad_x, bool dont_pad_y, string &errMsg, bool partitionByCol) {
   if (path.size() == 0) {
     throw runtime_error("Invalid filepath: " + path);
   }
@@ -77,7 +77,7 @@ int load_matrix_data(pdb::PDBClient &pdbClient, string path, pdb::String dbName,
 
         pdb::Handle<FFMatrixBlock> myData =
             pdb::makeObject<FFMatrixBlock>(i, j, actual_blockX, actual_blockY,
-                                           matrix.size(), matrix[0].size());
+                                           matrix.size(), matrix[0].size(), partitionByCol);
 
         for (int ii = 0; ii < actual_blockX; ii++) {
           for (int jj = 0; jj < actual_blockY; jj++) {
@@ -234,23 +234,38 @@ void load_matrix_from_file(string path, vector<vector<double>> &matrix) {
   }
 }
 
+bool is_empty_set(pdb::PDBClient &pdbClient, pdb::CatalogClient &catalogClient, string dbName, string setName) {
+  if (!catalogClient.setExists(dbName, setName))
+    return true;
+
+  auto it = pdbClient.getSetIterator<FFMatrixBlock>(dbName, setName);
+  int count = 0;
+  for (auto r : it) {
+    count++;
+  }
+
+  if (count != 0)
+    cout << "[VALIDATE] Set " << setName << " exists!" << endl;
+
+  return count == 0;
+}
+
 void print(pdb::PDBClient &pdbClient, string dbName, string setName) {
   auto it = pdbClient.getSetIterator<FFMatrixBlock>(dbName, setName);
 
-  cout << setName << ": ";
-  bool done = false;
   for (auto r : it) {
-    if (!done) {
-      done = true;
-      cout << "Actual dimensions: (" << r->getTotalRowNums() << ", "
-           << r->getTotalColNums()
-           << "), Block position: " << r->getBlockRowIndex() << ", "
-           << r->getBlockColIndex() << " : Block size: (" << r->getRowNums()
-           << ", " << r->getColNums() << ")" << endl;
-    }
-    double *data = r->getRawDataHandle()->c_ptr();
-    for (int i = 0; i < r->getRowNums() * r->getColNums(); i++) {
-      cout << data[i] << ",";
+    double *ndata = r->getRawDataHandle()->c_ptr();
+    int x = r->getBlockRowIndex();
+    int y = r->getBlockColIndex();
+    int bx = r->getRowNums();
+    int by = r->getColNums();
+
+    cout << "[PRINT] " << setName << " : " << x << "," << y << "; Block Size: " << bx << "," << by << endl;
+    for (int i = 0; i < bx; i++) {
+      for (int j = 0; j < by; j++) {
+        cout << ndata[i * by + j] << ",";
+      }
+      cout << endl;
     }
     cout << endl;
   }
@@ -262,6 +277,7 @@ void print_stats(pdb::PDBClient &pdbClient, string dbName, string setName) {
   int blockRows = 0, blockCols = 0;
   auto it = pdbClient.getSetIterator<FFMatrixBlock>(dbName, setName);
 
+  cout << "[STATS]: " << setName << endl;
   for (auto r : it) {
     cout << r->getBlockRowIndex() << "," << r->getBlockColIndex() << ";";
     rows = r->getRowNums();

--- a/src/FF/source/SimpleFF.cc
+++ b/src/FF/source/SimpleFF.cc
@@ -25,9 +25,21 @@ void loadLibrary(pdb::PDBClient &pdbClient, string path) {
   }
 }
 
+void createSet(pdb::PDBClient &pdbClient, string dbName, string setName, string setName1) {
+  string errMsg;
+  pdbClient.removeSet(dbName, setName, errMsg);
+  if (!pdbClient.createSet<FFMatrixBlock>(
+          dbName, setName, errMsg, (size_t)64 * (size_t)1024 * (size_t)1024,
+          setName1)) {
+    cout << "Not able to create set: " + errMsg;
+    //exit(-1); //It is possible that the set exists
+  } else {
+    cout << "Created set.\n";
+  }
+}
+
 void createSet(pdb::PDBClient &pdbClient, string dbName, string setName,
                string setName1, string jobName, string computationName, string lambdaName) {
-
   string errMsg;
   pdbClient.removeSet(dbName, setName, errMsg);
   Handle<LambdaIdentifier> identifier = pdb::makeObject<LambdaIdentifier>(jobName, computationName, lambdaName);
@@ -66,12 +78,13 @@ void setup(pdb::PDBClient &pdbClient, string database) {
   loadLibrary(pdbClient, "libraries/libFFTransposeBiasSum.so");
   loadLibrary(pdbClient, "libraries/libFFRowAggregate.so");
   loadLibrary(pdbClient, "libraries/libFFOutputLayer.so");
+}
 
-  createSet(pdbClient, database, "y1", "Y1");
-
-  createSet(pdbClient, database, "y2", "Y2");
-
-  createSet(pdbClient, database, "yo", "YO");
+void cleanup(pdb::PDBClient &pdblient, string database) {
+  string errMsg;
+  // pdblient.removeSet(database, "y1", errMsg);
+  // pdblient.removeSet(database, "y2", errMsg);
+  // pdblient.removeSet(database, "yo", errMsg);
 }
 
 void inference_compute(pdb::PDBClient &pdbClient, string database, string w1,
@@ -122,6 +135,23 @@ void inference_compute(pdb::PDBClient &pdbClient, string database, string w1,
     }
   }
 
+   pdbClient.flushData (errMsg);
+
+#ifdef DEBUG_SIMPLE_FF
+  {
+    const pdb::UseTemporaryAllocationBlock tempBlock{1024 * 1024 * 128};
+
+    print_stats(pdbClient, database, w1);
+    print(pdbClient, database, w1);
+    print_stats(pdbClient, database, inputs);
+    print(pdbClient, database, inputs);
+    print_stats(pdbClient, database, b1);
+    print(pdbClient, database, b1);
+    print_stats(pdbClient, database, "y1");
+    print(pdbClient, database, "y1");
+  }
+#endif
+
   {
     const pdb::UseTemporaryAllocationBlock tempBlock{1024 * 1024 * 128};
 
@@ -164,7 +194,22 @@ void inference_compute(pdb::PDBClient &pdbClient, string database, string w1,
     }
   }
 
-  pdbClient.deleteSet(database, "y1");
+   pdbClient.flushData (errMsg);
+
+#ifdef DEBUG_SIMPLE_FF
+  {
+    const pdb::UseTemporaryAllocationBlock tempBlock{1024 * 1024 * 128};
+
+    print_stats(pdbClient, database, w2);
+    print(pdbClient, database, w2);
+    print_stats(pdbClient, database, "y1");
+    print(pdbClient, database, "y1");
+    print_stats(pdbClient, database, b2);
+    print(pdbClient, database, b2);
+    print_stats(pdbClient, database, "y2");
+    print(pdbClient, database, "y2");
+  }
+#endif
 
   {
     const pdb::UseTemporaryAllocationBlock tempBlock{1024 * 1024 * 128};
@@ -204,7 +249,22 @@ void inference_compute(pdb::PDBClient &pdbClient, string database, string w1,
     }
   }
 
-  pdbClient.deleteSet(database, "y2");
+   pdbClient.flushData (errMsg);
+
+#ifdef DEBUG_SIMPLE_FF
+  {
+    const pdb::UseTemporaryAllocationBlock tempBlock{1024 * 1024 * 128};
+
+    print_stats(pdbClient, database, wo);
+    print(pdbClient, database, wo);
+    print_stats(pdbClient, database, "y2");
+    print(pdbClient, database, "y2");
+    print_stats(pdbClient, database, bo);
+    print(pdbClient, database, bo);
+    print_stats(pdbClient, database, "yo");
+    print(pdbClient, database, "yo");
+  }
+#endif
 }
 
 void inference(pdb::PDBClient &pdbClient, string database, string w1, string w2,
@@ -239,8 +299,6 @@ void inference(pdb::PDBClient &pdbClient, string database, string w1, string w2,
       exit(1);
     }
   }
-
-  pdbClient.deleteSet(database, "yo");
 }
 
 void inference(pdb::PDBClient &pdbClient, string database, string w1, string w2,

--- a/src/tests/source/LoadRedditComments.cc
+++ b/src/tests/source/LoadRedditComments.cc
@@ -61,8 +61,9 @@ void parseInputJSONFile(PDBClient &pdbClient, std::string fileName, int blockSiz
           if (strcmp(comment->author.c_str(), "[deleted]") !=0){
               //classify_v1(comment);
               classify(comment);
-              i++;
+              comment->index = i;
               storeMe->push_back(comment);
+              i++;
           }
       }
       catch (pdb::NotEnoughSpace &n) {

--- a/src/tests/source/RedditFeatureExtractor.cc
+++ b/src/tests/source/RedditFeatureExtractor.cc
@@ -70,6 +70,7 @@ int main(int argc, char *argv[]) {
   block_x = atoi(argv[3]);
   block_y = atoi(argv[4]);
   batch_size = atoi(argv[5]);
+  cout << "Batch Size: " << batch_size << endl;
   cout << "Using block dimensions " << block_x << ", " << block_y << endl;
 
   bool generate = argc == 6;
@@ -93,21 +94,48 @@ int main(int argc, char *argv[]) {
   ff::loadLibrary(pdbClient, "libraries/libFFRowAggregate.so");
   ff::loadLibrary(pdbClient, "libraries/libFFOutputLayer.so");
 
-  //specify the partitioning condition here
-  
-  if (enablePartition) {
-      std::string loadJobId = set;
-      std::string jobName = "inference-1";
-      std::string computationName = "JoinComp_2";
-      std::string lambdaName = "methodCall_1"; 
-      std::string errMsg;
-      Handle<LambdaIdentifier> identifier = pdb::makeObject<LambdaIdentifier>(jobName, computationName, lambdaName);
-      pdbClient.createSet<FFMatrixBlock>(db, set, errMsg, 64*1024*1024, loadJobId, nullptr, identifier);//getBlockColIndex
+  pdbClient.removeSet(db, "w1", errMsg);
+  pdbClient.removeSet(db, "b1", errMsg);
+  pdbClient.removeSet(db, "y1", errMsg);
+  pdbClient.removeSet(db, "w2", errMsg);
+  pdbClient.removeSet(db, "b2", errMsg);
+  pdbClient.removeSet(db, "y2", errMsg);
+  pdbClient.removeSet(db, "wo", errMsg);
+  pdbClient.removeSet(db, "bo", errMsg);
+  pdbClient.removeSet(db, "yo", errMsg);
+  pdbClient.removeSet(db, "output", errMsg);
+  pdbClient.removeSet(db, "inference", errMsg);
+  pdbClient.removeSet(db, "labeled_comments", errMsg);
+  pdbClient.removeSet(db, "comment_features", errMsg);
+  pdbClient.flushData(errMsg);
+
+  ff::cleanup(pdbClient, db);
+
+  {
+    const pdb::UseTemporaryAllocationBlock tempBlock{1024 * 1024 * 128};
+
+    if (!ff::is_empty_set(pdbClient, catalogClient, db, "w1") ||
+        !ff::is_empty_set(pdbClient, catalogClient, db, "b1") ||
+        !ff::is_empty_set(pdbClient, catalogClient, db, "y1") ||
+        !ff::is_empty_set(pdbClient, catalogClient, db, "w2") ||
+        !ff::is_empty_set(pdbClient, catalogClient, db, "b2") ||
+        !ff::is_empty_set(pdbClient, catalogClient, db, "y2") ||
+        !ff::is_empty_set(pdbClient, catalogClient, db, "wo") ||
+        !ff::is_empty_set(pdbClient, catalogClient, db, "bo") ||
+        !ff::is_empty_set(pdbClient, catalogClient, db, "yo") ||
+        !ff::is_empty_set(pdbClient, catalogClient, db, "output") ||
+        !ff::is_empty_set(pdbClient, catalogClient, db, "inference") ||
+        !ff::is_empty_set(pdbClient, catalogClient, db, "labeled_comments") ||
+        !ff::is_empty_set(pdbClient, catalogClient, db, "comment_features")) {
+          cout << "Old data exists!" << endl;
+          exit(1);
+        }
   }
-  else
+
+  //specify the partitioning condition here
+  if (!enablePartition) {
       ff::createSet(pdbClient, db, set, set);
 
-  if (!enablePartition) {
       ff::createSet(pdbClient, db, "w1", "W1");
       ff::createSet(pdbClient, db, "b1", "B1");
       ff::createSet(pdbClient, db, "y1", "Y1");
@@ -120,13 +148,15 @@ int main(int argc, char *argv[]) {
       ff::createSet(pdbClient, db, "bo", "BO");
       ff::createSet(pdbClient, db, "yo", "YO");
   } else {
+      ff::createSet(pdbClient, db, set, "CommentFeatures", "inference-1", "JoinComp_2", "methodCall_1");//getBlockColIndex
+
       ff::createSet(pdbClient, db, "w1", "W1", "inference-1", "JoinComp_2", "methodCall_0");//getBlockColIndex
       ff::createSet(pdbClient, db, "b1", "B1", "inference-1", "JoinComp_5", "methodCall_1");//getBlockRowIndex
-      ff::createSet(pdbClient, db, "y1", "Y1", "inference-2", "JoinComp_2", "methodCall_1");//getBlockColIndex
+      ff::createSet(pdbClient, db, "y1", "Y1", "inference-2", "JoinComp_2", "methodCall_1");//getBlockRowIndex
 
       ff::createSet(pdbClient, db, "w2", "W2", "inference-2", "JoinComp_2", "methodCall_0");//getBlockColIndex
       ff::createSet(pdbClient, db, "b2", "B2", "inference-2", "JoinComp_5", "methodCall_1");//getRowIndex
-      ff::createSet(pdbClient, db, "y2", "Y2", "inference-3", "JoinComp_2", "methodCall_1");//getBlockColIndex
+      ff::createSet(pdbClient, db, "y2", "Y2", "inference-3", "JoinComp_2", "methodCall_1");//getBlockRowIndex
 
       ff::createSet(pdbClient, db, "wo", "WO", "inference-3", "JoinComp_2", "methodCall_0");//getBlockColIndex
       ff::createSet(pdbClient, db, "bo", "BO", "inference-3", "JoinComp_5", "methodCall_1");//getBlockRowIndex
@@ -160,17 +190,17 @@ int main(int argc, char *argv[]) {
 
     // load the input data
     (void)ff::load_matrix_data(pdbClient, w1_path, db, "w1", block_x, block_y,
-                               false, false, errMsg);
+                               false, false, errMsg, true);
     (void)ff::load_matrix_data(pdbClient, w2_path, db, "w2", block_x, block_y,
-                               false, false, errMsg);
+                               false, false, errMsg, true);
     (void)ff::load_matrix_data(pdbClient, wo_path, db, "wo", block_x, block_y,
-                               false, false, errMsg);
+                               false, false, errMsg, true);
     (void)ff::load_matrix_data(pdbClient, b1_path, db, "b1", block_x, block_y,
-                               false, true, errMsg);
+                               false, true, errMsg, false);
     (void)ff::load_matrix_data(pdbClient, b2_path, db, "b2", block_x, block_y,
-                               false, true, errMsg);
+                               false, true, errMsg, false);
     (void)ff::load_matrix_data(pdbClient, bo_path, db, "bo", block_x, block_y,
-                               false, true, errMsg);
+                               false, true, errMsg, false);
   } else {
     int hid1_size = 128;
     int hid2_size = 256;
@@ -178,25 +208,44 @@ int main(int argc, char *argv[]) {
 
     // 128 x 9 = 128 x 9
     ff::loadMatrix(pdbClient, db, "w1", hid1_size, total_features, block_x,
-                   block_y, false, false, errMsg);
+                   block_y, false, false, errMsg, true);
     // 128 x 1
     ff::loadMatrix(pdbClient, db, "b1", hid1_size, 1, block_x, block_y, false,
                    true, errMsg, false);
 
     // 256 x 128
     ff::loadMatrix(pdbClient, db, "w2", hid2_size, hid1_size, block_x, block_y,
-                   false, false, errMsg);
+                   false, false, errMsg, true);
     // 256 x 1
     ff::loadMatrix(pdbClient, db, "b2", hid2_size, 1, block_x, block_y, false,
                    true, errMsg, false);
 
     // 2 x 256
     ff::loadMatrix(pdbClient, db, "wo", num_labels, hid2_size, block_x, block_y,
-                   false, false, errMsg);
+                   false, false, errMsg, true);
     // 2 x 1
     ff::loadMatrix(pdbClient, db, "bo", num_labels, 1, block_x, block_y, false,
                    true, errMsg, false);
   }
+
+#ifdef DEBUG_SIMPLE_FF
+  {
+    const pdb::UseTemporaryAllocationBlock tempBlock{1024 * 1024 * 128};
+
+    ff::print_stats(pdbClient, db, "w1");
+    ff::print(pdbClient, db, "w1");
+    ff::print_stats(pdbClient, db, "w2");
+    ff::print(pdbClient, db, "w2");
+    ff::print_stats(pdbClient, db, "wo");
+    ff::print(pdbClient, db, "wo");
+    ff::print_stats(pdbClient, db, "b1");
+    ff::print(pdbClient, db, "b1");
+    ff::print_stats(pdbClient, db, "b2");
+    ff::print(pdbClient, db, "b2");
+    ff::print_stats(pdbClient, db, "bo");
+    ff::print(pdbClient, db, "bo");
+  }
+#endif
 
   ff::loadLibrary(pdbClient, "libraries/libRedditCommentFeatures.so");
   ff::loadLibrary(pdbClient, "libraries/libRedditCommentFeatureChunks.so");
@@ -240,7 +289,7 @@ int main(int argc, char *argv[]) {
 
     auto begin = std::chrono::high_resolution_clock::now();
     // run the computation
-    if (!pdbClient.executeComputations(errMsg, myWriter)) {
+    if (!pdbClient.executeComputations(errMsg, "blocking-0", myWriter)) {
       cout << "Computation failed. Message was: " << errMsg << "\n";
       exit(1);
     }
@@ -257,6 +306,8 @@ int main(int argc, char *argv[]) {
     }
     std::cout << "count: " << count << std::endl;
   }
+
+  pdbClient.flushData (errMsg);
 
   ff::loadLibrary(pdbClient, "libraries/libRedditCommentInferenceJoin.so");
   ff::loadLibrary(pdbClient, "libraries/libFFMatrixMultiSel.so");
@@ -303,6 +354,25 @@ int main(int argc, char *argv[]) {
               << " secs." << std::endl;
   }
 
+  pdbClient.flushData (errMsg);
+
+#ifdef DEBUG_SIMPLE_FF
+  {
+    const pdb::UseTemporaryAllocationBlock tempBlock{1024 * 1024 * 128};
+
+    ff::print_stats(pdbClient, db, "yo");
+    ff::print(pdbClient, db, "yo");
+    
+    auto it = pdbClient.getSetIterator<InferenceResult>(db, "output");
+
+    for (auto r : it) {
+      cout << "[PRINT] output : " << r->getKey() << ",0; Block Size: 1,2" << endl;
+      r->print();
+    }
+    cout << endl;
+  }
+#endif
+
   // Join the partitioned inference results with comments
   {
 
@@ -337,28 +407,22 @@ int main(int argc, char *argv[]) {
               << " secs." << std::endl;
   }
 
-  pdbClient.deleteSet(db, "w1");
-  pdbClient.deleteSet(db, "b1");
-  pdbClient.deleteSet(db, "w2");
-  pdbClient.deleteSet(db, "b2");
-  pdbClient.deleteSet(db, "wo");
-  pdbClient.deleteSet(db, "bo");
-  pdbClient.deleteSet(db, "output");
-
   pdbClient.flushData(errMsg);
 
-   {
-     const pdb::UseTemporaryAllocationBlock tempBlock{1024 * 1024 * 1024};
+#ifdef DEBUG_SIMPLE_FF
+  {
+    const pdb::UseTemporaryAllocationBlock tempBlock{1024 * 1024 * 1024};
 
-     auto it = pdbClient.getSetIterator<reddit::Comment>(db, "labeled_comments");
+    auto it = pdbClient.getSetIterator<reddit::Comment>(db, "labeled_comments");
 
-//     int count = 0;
-//     for (auto r : it) {
-//       //cout << r->label << endl;
-//       count++;
-//     }
-//     std::cout << "count = " << count << std::endl;
-   }
+    int count = 0;
+    for (auto r : it) {
+      cout << r->label << endl;
+      count++;
+    }
+    std::cout << "count = " << count << std::endl;
+  }
+#endif
 
   pdbClient.registerType("libraries/libRedditComment.so", errMsg);
   pdbClient.registerType("libraries/libRedditAuthor.so", errMsg);


### PR DESCRIPTION
1. Flush data after every computation execution so that data is available
for next computation.
2. Update matrix file loading to include partition option.